### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/scp-chunk.py
+++ b/scp-chunk.py
@@ -167,7 +167,7 @@ def human2bytes(s):
             sset = SYMBOLS['customary']
             letter = letter.upper()
         else:
-            raise ValueError("can't interpret %r" % init)
+            raise ValueError("can't interpret {0!r}".format(init))
     prefix = {sset[0]: 1}
     for i, s in enumerate(sset[1:]):
         prefix[s] = 1 << (i + 1) * 10
@@ -390,7 +390,7 @@ def main():
                                                       chunk_size)
     src_file_md5 = src_file_info[1]
     local_chunk_end_time = time.time()
-    print "uploading MD5 (%s) checksum to remote site" % src_file_md5
+    print "uploading MD5 ({0!s}) checksum to remote site".format(src_file_md5)
     try:
         checksum_filename = src_file+'.md5'
         dest_checksum_filename = os.path.join(dest_path,src_filename+'.md5')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sohonetlabs:scp-chunk?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sohonetlabs:scp-chunk?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)